### PR TITLE
Update for GNU Radio 3.10 release and add GNU Radio 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-### A docker container with the release version of GNU Radio (3.9 right now) in the latest stable Ubuntu (plus a 3.8 version in Ubuntu 20.04 and a 3.7 version in Ubuntu 18.04)
+### A docker container with the release version of GNU Radio (3.10 right now) in the latest stable Ubuntu (plus 3.9 and 3.8 versions in Ubuntu 20.04, and a 3.7 version in Ubuntu 18.04)
 
 ![Screenshot of three GNU Radios](https://iie.fing.edu.uy/~flarroca/todos_gnuradio.png)
 
 I have originally prepared these Dockerfiles to be able to migrate my OOT modules to 3.8 and not mess the 3.7 installation of my host PC. The resulting container has the GUI available (so you may use the gnuradio companion and QT widgets) as well as audio. Several packages needed to compile OOTs are also installed and configured. 
 
-If you want the release version of GNU Radio (currently 3.9): 
+If you want the release version of GNU Radio (currently 3.10): 
 
 1. Install docker by following [Docker's installation guide](https://docs.docker.com/get-docker/) (though I've tested this on Ubuntu only, so for convenience a direct link to the corresponding [guide for Ubuntu](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository)). 
 1. Clone this repo: `git clone https://github.com/git-artes/docker-gnuradio.git`
@@ -13,12 +13,19 @@ If you want the release version of GNU Radio (currently 3.9):
 
 You will then be in a comand line logged as user *gnuradio* who is a sudoer (password: *gnuradio*). The folder *persistent* in its home directory will persist even after you exit the container. **Remember**: everything else is erased after you exit the container. This means for instance that if you compile and install an OOT you will have to do that again every time you run the container (unless for instance you compile in the *persistent* folder). You may modify Dockerfile to avoid this. 
 
-I've also made a couple of Dockers container for GNU Radio 3.8 (in Ubuntu 20.04), and GNU Radio 3.7 (in Ubuntu 18.04) to check on compatibility issues regarding my OOTs. In the first case, instead of the last two steps above you have to: 
+I've also made a couple of Dockers container for GNU Radio 3.9 and GNU Radio 3.8 (in Ubuntu 20.04), and GNU Radio 3.7 (in Ubuntu 18.04) to check on compatibility issues regarding my OOTs. In the first case, instead of the last two steps above you have to: 
+
+If you want GNU Radio 3.9:
+
+1. Enter the `docker-gnuradio/gnuradio-releases-39` folder and execute `docker build -t ubuntu:gnuradio-releases-3.9 .` (again, this step is only necessary once)
+2. Run the container: `docker run --net=host --env="DISPLAY" --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --privileged --device /dev/snd -v persistent-39:/home/gnuradio/persistent --group-add=audio -it ubuntu:gnuradio-releases-3.9 bash`. 
+
+If you want GNU Radio 3.8:
 
 1. Enter the `docker-gnuradio/gnuradio-releases-38` folder and execute `docker build -t ubuntu:gnuradio-releases-3.8 .` (again, this step is only necessary once)
 2. Run the container: `docker run --net=host --env="DISPLAY" --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --privileged --device /dev/snd -v persistent-38:/home/gnuradio/persistent --group-add=audio -it ubuntu:gnuradio-releases-3.8 bash`. 
 
-If you want the GNU Radio 3.7 instead:
+If you want GNU Radio 3.7:
 
 1. Enter the `docker-gnuradio/gnuradio-releases-37` folder and execute `docker build -t ubuntu:gnuradio-releases-3.7 .` (again, this step is only necessary once)
 2. Run the container: `docker run --net=host --env="DISPLAY" --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --privileged --device /dev/snd -v persistent-37:/home/gnuradio/persistent --group-add=audio -it ubuntu:gnuradio-releases-3.7 bash`. 
@@ -36,5 +43,4 @@ Universidad de la República
 Montevideo, Uruguay  
 http://iie.fing.edu.uy/investigacion/grupos/artes/  
  
-
 

--- a/gnuradio-releases-39/Dockerfile
+++ b/gnuradio-releases-39/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:20.04
+LABEL maintainer="Federico 'Larroca' La rocca - flarroca@fing.edu.uy"
+
+#ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+
+# else it will output an error about Gtk namespace not found
+RUN apt-get install -y gir1.2-gtk-3.0
+
+# to have add-apt-repository available
+RUN apt-get install -y software-properties-common
+
+RUN add-apt-repository -y ppa:gnuradio/gnuradio-releases-3.9
+
+# create user gnuario with sudo (and password gnuradio)
+RUN apt-get install -y sudo
+RUN useradd --create-home --shell /bin/bash -G sudo gnuradio
+RUN echo 'gnuradio:gnuradio' | chpasswd
+
+# I create a dir at home which I'll use to persist after the container is closed (need to change it's ownership)
+RUN mkdir /home/gnuradio/persistent  && chown gnuradio /home/gnuradio/persistent
+
+RUN apt-get update
+
+RUN apt-get install -y gnuradio
+
+# installing other packages needed for downloading and installing OOT modules
+RUN apt-get install -y gnuradio-dev cmake git libboost-all-dev libcppunit-dev liblog4cpp5-dev python3-pygccxml pybind11-dev liborc-dev
+
+# of course, nothing useful can be done without vim
+RUN apt-get install -y vim 
+
+USER gnuradio
+
+WORKDIR /home/gnuradio
+
+ENV PYTHONPATH "${PYTHONPATH}:/usr/local/lib/python3/dist-packages"
+
+CMD bash

--- a/gnuradio-releases/Dockerfile
+++ b/gnuradio-releases/Dockerfile
@@ -26,10 +26,13 @@ RUN apt-get update
 RUN apt-get install -y gnuradio
 
 # installing other packages needed for downloading and installing OOT modules
-RUN apt-get install -y gnuradio-dev cmake git libboost-all-dev libcppunit-dev liblog4cpp5-dev python3-pygccxml pybind11-dev liborc-dev
+RUN apt-get install -y gnuradio-dev cmake git libboost-all-dev libcppunit-dev liblog4cpp5-dev python3-pygccxml pybind11-dev liborc-dev python3-pip
 
 # of course, nothing useful can be done without vim
 RUN apt-get install -y vim 
+
+# Fix dependency issue as noted on 'InstallingGR' wiki page for 3.10
+RUN pip install packaging
 
 USER gnuradio
 


### PR DESCRIPTION
Add a Dockerfile for GNU Radio 3.9, and update Documentation. GNU Radio 3.10 is now the default version.